### PR TITLE
Upgrade image to 0.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default = ["console_error_panic_hook"]
 [dependencies]
 cfg-if = "0.1"
 wasm-bindgen = "0.2"
-image = "0.20"
+image = "0.23"
 js-sys = "0.3"
 imageproc = "0.17"
 

--- a/src/edge.rs
+++ b/src/edge.rs
@@ -6,7 +6,7 @@ use std::cmp::{max, min};
 use std::mem::transmute;
 use std::{f32, i16};
 
-static BLACK_32: Luma<f32> = Luma { data: [0.0] };
+static BLACK_32: Luma<f32> = Luma([0.0]);
 
 /// Sobel filter for detecting vertical gradients.
 static VERTICAL_SOBEL: [i32; 9] = [-1, -2, -1, 0, 0, 0, 1, 2, 1];
@@ -129,7 +129,7 @@ fn hysteresis(
     let color: [u8; 4] = unsafe { transmute(hue.to_be()) };
     let low_thresh = low_thresh * low_thresh;
     let high_thresh = high_thresh * high_thresh;
-    let pixel = image::Rgba { data: color };
+    let pixel = image::Rgba(color);
     // Init output image as all black.
     let (width, height) = input.dimensions();
     let mut edges = Vec::with_capacity((width as usize * height as usize) / 2);
@@ -230,9 +230,9 @@ pub fn filter(
             hacc = 0_i32;
             vacc = 0_i32;
             unsafe {
-                hout.unsafe_put_pixel(x, y, Luma { data: [h] });
-                vout.unsafe_put_pixel(x, y, Luma { data: [v] });
-                out.unsafe_put_pixel(x, y, Luma { data: [p] });
+                hout.unsafe_put_pixel(x, y, Luma([h]));
+                vout.unsafe_put_pixel(x, y, Luma([v]));
+                out.unsafe_put_pixel(x, y, Luma([p]));
             };
         }
     }
@@ -251,7 +251,7 @@ fn clamp(x: i32) -> i16 {
 }
 
 fn accumulate(acc: i32, pixel: &Luma<u8>, weight: i32) -> i32 {
-    acc + (pixel.data[0] as i32) * weight
+    acc + ((pixel.0)[0] as i32) * weight
 }
 
 // borrowed this code from: https://gist.github.com/volkansalma/2972237

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ extern crate wasm_bindgen;
 mod edge;
 mod utils;
 
-use image::{GenericImageView, GrayImage, Pixel, RgbaImage};
+use image::{RgbaImage, DynamicImage};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::Clamped;
 
@@ -26,9 +26,7 @@ pub fn detect(
         .expect("Could not load image from input buffer");
 
     // convert image buffer to grayscale (luma) buffer;
-    let gray_image = GrayImage::from_fn(width, height, |x, y| {
-        (unsafe { source_buffer.unsafe_get_pixel(x, y).to_luma() })
-    });
+    let gray_image = DynamicImage::ImageRgba8(source_buffer.clone()).into_luma();
 
     // create gray image from gray image buffer
     edge::canny(
@@ -59,7 +57,7 @@ mod tests {
         let width = img.width();
         let height = img.height();
         let raw = Clamped(img.to_rgba().into_raw());
-        let out = detect(raw, width, height, ORANGE);
+        let out = detect(raw, width, height, ORANGE, false);
         let out_buf = image::RgbaImage::from_vec(width, height, out.to_vec())
             .expect("Could not load image from buf");
 


### PR DESCRIPTION
Among the related fixes, change the way the initial luma image is
created. This performs better than the previous unsafe version.